### PR TITLE
Fix sampling issue for rotation increments

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,17 @@
 
 Generate uniform 3D euler angles (ZYZ)
 
-Install via source using
+## Installation
+
+Install via pip
 ```zsh
+pip install torch-angular-search
+```
+
+Install via source by first cloning the repository then running.
+```zsh
+git clone https://github.com/jdickerson95/torch-angular-search.git
+cd torch-angular-search
 pip install -e .
 ```
 And for development and testing use
@@ -17,7 +26,22 @@ And for development and testing use
 pip install -e ".[dev,test]"
 ```
 
-Make sure to run tests before any commits:
+For those contributing make sure to run tests before, and to adhere to the pre-commit hooks.
 ```zsh
 python -m pytest
+pre-commit run
+```
+
+## Usage
+
+A basic example of generating uniform Euler angles in 4.0 and 6.0 degree increments across the entire SO(3) group is shown below.
+
+```python
+from torch_angular_search.hopf_angles import get_uniform_euler_angles
+
+angles = get_uniform_euler_angles(
+    in_plane_step=4.0,  # units of degrees
+    out_of_plane_step=6.0,
+)
+angles.shape  # (103500, 3)
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ classifiers = [
 dependencies = [
     "torch",
     "numpy",
+    "roma",
 ]
 
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies

--- a/src/torch_angular_search/hopf_angles.py
+++ b/src/torch_angular_search/hopf_angles.py
@@ -1,108 +1,101 @@
 """Generate multiple sets of uniform Euler angles using Hopf fibration."""
 
+import numpy as np
 import torch
 
 
 def get_uniform_euler_angles(
     in_plane_step: float = 1.5,
     out_of_plane_step: float = 2.5,
-    phi_ranges: torch.Tensor = None,
-    theta_ranges: torch.Tensor = None,
-    psi_ranges: torch.Tensor = None,
-) -> list:
+    phi_min: float = 0.0,
+    phi_max: float = 360.0,
+    theta_min: float = 0.0,
+    theta_max: float = 180.0,
+    psi_min: float = 0.0,
+    psi_max: float = 360.0,
+) -> torch.Tensor:
     """Generate sets of uniform Euler angles (ZYZ) using Hopf fibration.
 
-    Args:
-        in_plane_step: Angular step for in-plane rotation (phi, psi) in degrees.
-        out_of_plane_step: Angular step for out-of-plane rotation (theta) in degrees.
-        phi_ranges: Tensor of shape (n, 2) specifying ranges for phi in degrees.
-        theta_ranges: Tensor of shape (n, 2) specifying ranges for theta in degrees.
-        psi_ranges: Tensor of shape (n, 2) specifying ranges for psi in degrees.
+    Parameters
+    ----------
+    in_plane_step: float, optional
+        Angular step for in-plane rotation (phi) in degrees. Default is 1.5 degrees.
+    out_of_plane_step: float, optional
+        Angular step for out-of-plane rotation (theta) in degrees. Default is 2.5
+        degrees.
+    phi_min: float, optional
+        Minimum value for phi in degrees. Default is 0.0.
+    phi_max: float, optional
+        Maximum value for phi in degrees. Default is 360.0.
+    theta_min: float, optional
+        Minimum value for theta in degrees. Default is 0.0.
+    theta_max: float, optional
+        Maximum value for theta in degrees. Default is 180.0.
+    psi_min: float, optional
+        Minimum value for psi in degrees. Default is 0.0.
+    psi_max: float, optional
+        Maximum value for psi in degrees. Default is 360.0.
 
     Returns
     -------
-        list of torch.Tensor of shape (N, 3),
-            where list length is the number of range sets,
-            and N is the number of Euler angles in each set.
+    torch.Tensor
+        Tensor of shape (N, 3) containing Euler angles in degrees, where N is the
+        number of angles generated.
     """
-    # Set default ranges if not provided
-    if phi_ranges is None:
-        phi_ranges = torch.tensor([[-180, 180]], dtype=torch.float64)
-    if theta_ranges is None:
-        theta_ranges = torch.tensor([[0, 180]], dtype=torch.float64)
-    if psi_ranges is None:
-        psi_ranges = torch.tensor([[-180, 180]], dtype=torch.float64)
-    # Convert step sizes to radians
-    in_plane_step = torch.deg2rad(torch.tensor(in_plane_step, dtype=torch.float64))
-    out_of_plane_step = torch.deg2rad(
-        torch.tensor(out_of_plane_step, dtype=torch.float64)
-    )
+    # TODO: Validation of inputs, wrapping between zero and 2*pi, etc.
+
+    # Convert input angles from degrees into radians
+    in_plane_step_rad = np.deg2rad(in_plane_step)
+    out_of_plane_step_rad = np.deg2rad(out_of_plane_step)
+    phi_min_rad = np.deg2rad(phi_min)
+    phi_max_rad = np.deg2rad(phi_max)
+    theta_min_rad = np.deg2rad(theta_min)
+    theta_max_rad = np.deg2rad(theta_max)
+    psi_min_rad = np.deg2rad(psi_min)
+    psi_max_rad = np.deg2rad(psi_max)
 
     # Initialize the list to store results
     all_euler_angles = []
 
-    # Iterate over the range sets
-    for i in range(phi_ranges.shape[0]):
-        # Extract and convert the current ranges to radians
-        phi_range = torch.deg2rad(phi_ranges[i])
-        theta_range = torch.deg2rad(theta_ranges[i])
-        psi_range = torch.deg2rad(psi_ranges[i])
+    # The grid of theta and psi values to search over
+    # NOTE: Including the 180.0 degree entry in theta_all since projection of
+    # non-symmetric object (e.g. ribosome) is different at 0.0 and 180.0 degrees
+    theta_all = torch.arange(
+        theta_min_rad,
+        theta_max_rad + out_of_plane_step_rad,
+        step=out_of_plane_step_rad,
+        dtype=torch.float64,
+    )
+    psi_all = torch.arange(
+        psi_min_rad,
+        psi_max_rad,
+        step=in_plane_step_rad,
+        dtype=torch.float64,
+    )
 
-        # Calculate the number of samples for each angle
-        n_theta = int(torch.ceil((theta_range[1] - theta_range[0]) / out_of_plane_step))
-        n_psi = int(torch.ceil((psi_range[1] - psi_range[0]) / in_plane_step))
+    # Phi step increment is modulated by the position on the sphere (sin(theta)), but
+    # don't allow it to exceed the maximum step size
+    phi_max_step = phi_max_rad - phi_min_rad
+    phi_step_all = torch.clamp(
+        torch.abs(out_of_plane_step_rad / torch.sin(theta_all)), max=phi_max_step
+    )
+    phi_step_all = phi_max_step / torch.round(phi_max_step / phi_step_all)
 
-        # Generate theta values (out-of-plane angle)
-        theta_all = torch.linspace(
-            theta_range[0], theta_range[1], n_theta, dtype=torch.float64
+    for j, phi_step in enumerate(phi_step_all):
+        phi_array = torch.arange(
+            phi_min_rad, phi_max_rad, phi_step, dtype=torch.float64
         )
-        psi_all = torch.linspace(psi_range[0], psi_range[1], n_psi, dtype=torch.float64)
-        # Wrap theta values around to the range of 0 to pi
-        theta_all = torch.where(theta_all < 0, theta_all * -1, theta_all)
-        theta_all = torch.where(
-            theta_all > torch.pi, 2 * torch.pi - theta_all, theta_all
+
+        grid_phi, grid_theta, grid_psi = torch.meshgrid(
+            phi_array,
+            theta_all[j],  # indexing only a single value from theta_all
+            psi_all,
+            indexing="ij",
         )
-        # Wrap psi values around to the range of -pi to pi
-        psi_all = torch.where(psi_all < -torch.pi, psi_all + 2 * torch.pi, psi_all)
-        psi_all = torch.where(psi_all > torch.pi, psi_all - 2 * torch.pi, psi_all)
+        euler_angles = torch.stack([grid_phi, grid_theta, grid_psi], dim=-1)
+        all_euler_angles.append(euler_angles.reshape(-1, 3))
 
-        # Generate phi values using Hopf fibration
-        phi_max_step = phi_range[1] - phi_range[0]
-        euler_angles = []
-        phi_step_all = torch.clamp(
-            torch.abs(out_of_plane_step / torch.sin(theta_all)), max=phi_max_step
-        )
-        phi_step_all = phi_max_step / torch.round(phi_max_step / phi_step_all)
+    all_euler_angles = torch.cat(all_euler_angles, dim=0)
+    all_euler_angles = torch.rad2deg(all_euler_angles)
 
-        for j, phi_step in enumerate(phi_step_all):
-            this_theta = theta_all[j]
-            phi_array = torch.arange(
-                phi_range[0], phi_range[1], phi_step, dtype=torch.float64
-            )  # eps effectively makes endpoint inclusive
-            # Wrap phi values around to the range of -pi to pi
-            phi_array = torch.where(
-                phi_array < -torch.pi, phi_array + 2 * torch.pi, phi_array
-            )
-            phi_array = torch.where(
-                phi_array > torch.pi, phi_array - 2 * torch.pi, phi_array
-            )
-            # Create all combinations using meshgrid
-            grid1, grid2, grid3 = torch.meshgrid(
-                phi_array, this_theta, psi_all, indexing="ij"
-            )
-            # Stack and reshape to get the desired shape
-            combinations = torch.stack([grid1, grid2, grid3], dim=-1).reshape(-1, 3)
-            # Append combinations to the tensor
-            euler_angles.append(combinations)
-
-        # Concatenate all generated angles for the current set of ranges
-        euler_angles = torch.cat(euler_angles, dim=0)
-        euler_angles = torch.rad2deg(euler_angles)
-
-        # Append to the list of all sets
-        all_euler_angles.append(euler_angles)
-
-    # Stack all sets to create a tensor of shape (n, N, 3)
-    # all_euler_angles = torch.stack(all_euler_angles, dim=0)
-
-    return all_euler_angles  # return list of tensors
+    return all_euler_angles

--- a/src/torch_angular_search/py.typed
+++ b/src/torch_angular_search/py.typed
@@ -1,5 +1,0 @@
-You may remove this file if you don't intend to add types to your package
-
-Details at:
-
-https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages

--- a/src/torch_angular_search/refine_search.py
+++ b/src/torch_angular_search/refine_search.py
@@ -4,159 +4,57 @@ import torch
 
 from torch_angular_search.hopf_angles import get_uniform_euler_angles
 
-eps = 1e-10
+EPS = 1e-10
 
 
-def increase_resolution(
+def increased_resolution_grid(
     coarse_in_plane_step: float = 1.5,
     coarse_out_of_plane_step: float = 2.5,
     fine_in_plane_step: float = 0.1,
     fine_out_of_plane_step: float = 0.1,
-) -> list:
-    """
-    Search around a pole at higher resolution.
+) -> torch.Tensor:
+    """Local orientation refinement from a coarse to fine grid.
 
-    Args:
-        coarse_in_plane_step (float):
-            Coarse step size for in-plane angles (phi, psi) in degrees.
-        coarse_out_of_plane_step (float):
-            Coarse step size for out-of-plane angle (theta) in degrees.
-        fine_in_plane_step (float):
-            Finer step size for in-plane angles (phi, psi) in degrees.
-        fine_out_of_plane_step (float):
-            Finer step size for out-of-plane angle (theta) in degrees.
+    Parameters
+    ----------
+    coarse_in_plane_step : float
+        Coarse step size for in-plane angles (phi, psi) in degrees.
+    coarse_out_of_plane_step : float
+        Coarse step size for out-of-plane angle (theta) in degrees.
+    fine_in_plane_step : float
+        Finer step size for in-plane angles (phi, psi) in degrees.
+    fine_out_of_plane_step : float
+        Finer step size for out-of-plane angle (theta) in degrees.
 
     Returns
     -------
-        list: List of torch tensors of shape (N, 3) in degrees,
-                      where N is the number of refined angles per best angle.
+    euler_angles : torch.Tensor
+        Tensor of shape (N, 3) containing Euler angles in degrees, where N is the
+        number of angles generated. Angles exist around pole (0, 0, 0) and define grid
+        to search over.
     """
     fine_theta_range = (
-        -coarse_out_of_plane_step
-        + fine_out_of_plane_step,  # so don't overlap old values
-        coarse_out_of_plane_step
-        - fine_out_of_plane_step,  # so don't overlap old values
+        -coarse_out_of_plane_step + fine_out_of_plane_step,
+        coarse_out_of_plane_step - fine_out_of_plane_step,
     )
     fine_psi_range = (
-        -coarse_in_plane_step + fine_in_plane_step,  # so don't overlap old values
-        coarse_in_plane_step - fine_in_plane_step,  # so don't overlap old values
+        -coarse_in_plane_step + fine_in_plane_step,
+        coarse_in_plane_step - fine_in_plane_step,
     )
 
     # Shouldn't need to run phi range for refined angles
-    phi_range = (0, eps)
+    phi_range = (0, EPS)
 
     # Now get angles using Hopf fibration
     euler_angles = get_uniform_euler_angles(
         in_plane_step=fine_in_plane_step,
         out_of_plane_step=fine_out_of_plane_step,
-        phi_ranges=torch.tensor([phi_range]),
-        theta_ranges=torch.tensor([fine_theta_range]),
-        psi_ranges=torch.tensor([fine_psi_range]),
+        phi_min=phi_range[0],
+        phi_max=phi_range[1],
+        theta_min=fine_theta_range[0],
+        theta_max=fine_theta_range[1],
+        psi_min=fine_psi_range[0],
+        psi_max=fine_psi_range[1],
     )
 
     return euler_angles
-
-
-'''
-This is deprecated. Not fully deleted yet.
-# I want to change this so instead of best angle, it just generates angles
-# around a pole. It is moved to best by rotation matrix
-def refine_euler_angles(
-    best_angles: torch.Tensor,
-    coarse_in_plane_step: float = 2.5,
-    coarse_out_of_plane_step: float = 1.5,
-    fine_in_plane_step: float = 0.1,
-    fine_out_of_plane_step: float = 0.1,
-    coarse_phi_range: torch.Tensor = None,
-) -> list:
-    """
-    Refine sampling around multiple selected Euler angles.
-
-    Args:
-        best_angles (torch.Tensor): Tensor of shape (NumBest, 3)
-            containing best [phi, theta, psi] angles in degrees.
-        coarse_in_plane_step (float):
-            Coarse step size for in-plane angles (phi, psi) in degrees.
-        coarse_out_of_plane_step (float):
-            Coarse step size for out-of-plane angle (theta) in degrees.
-        fine_in_plane_step (float):
-            Finer step size for in-plane angles (phi, psi) in degrees.
-        fine_out_of_plane_step (float):
-            Finer step size for out-of-plane angle (theta) in degrees.
-        coarse_phi_range (torch.Tensor):
-            Range of coarse phi angles in degrees.
-
-    Returns
-    -------
-        list: List of torch tensors of shape (N, 3) in degrees,
-                      where N is the number of refined angles per best angle.
-    """
-    if coarse_phi_range is None:
-        coarse_phi_range = torch.tensor([-180, 180], dtype=torch.float64)
-    # Convert angles to radians
-    coarse_in_plane_step_tensor = torch.deg2rad(
-        torch.tensor(coarse_in_plane_step, dtype=torch.float64)
-    )
-    coarse_out_of_plane_step_tensor = torch.deg2rad(
-        torch.tensor(coarse_out_of_plane_step, dtype=torch.float64)
-    )
-    fine_in_plane_step_tensor = torch.deg2rad(
-        torch.tensor(fine_in_plane_step, dtype=torch.float64)
-    )
-    fine_out_of_plane_step_tensor = torch.deg2rad(
-        torch.tensor(fine_out_of_plane_step, dtype=torch.float64)
-    )
-    best_angles = torch.deg2rad(best_angles)
-
-    fine_theta_ranges = (
-        best_angles[:, 1]
-        - coarse_out_of_plane_step_tensor
-        + fine_out_of_plane_step_tensor,  # so don't overlap old values
-        best_angles[:, 1]
-        + coarse_out_of_plane_step_tensor
-        - fine_out_of_plane_step_tensor,  # so don't overlap old values
-    )
-    fine_psi_ranges = (
-        best_angles[:, 2]
-        - coarse_in_plane_step_tensor
-        + fine_in_plane_step_tensor,  # so don't overlap old values
-        best_angles[:, 2]
-        + coarse_in_plane_step_tensor
-        - fine_in_plane_step_tensor,  # so don't overlap old values
-    )
-
-    # Stack the tensors to create shape (n, 2)
-    fine_theta_ranges_tensor = torch.rad2deg(torch.stack(fine_theta_ranges, dim=1))
-    fine_psi_ranges_tensor = torch.rad2deg(torch.stack(fine_psi_ranges, dim=1))
-
-    # now get the Hopf fibration for the phi angles using coarse.
-    # i.e. for tall best thetas, get what the phi step would have been
-    phi_max_step = coarse_phi_range[1] - coarse_phi_range[0]
-    phi_step_all = torch.clamp(
-        torch.abs(coarse_out_of_plane_step_tensor / torch.sin(best_angles[:, 1])),
-        max=phi_max_step,
-    )
-    phi_step_all = phi_max_step / torch.round(phi_max_step / phi_step_all)
-    # get phi range
-    phi_step_all_fine = torch.clamp(
-        torch.abs(fine_out_of_plane_step_tensor / torch.sin(best_angles[:, 1])),
-        max=phi_max_step,
-    )
-    phi_step_all_fine = phi_max_step / torch.round(phi_max_step / phi_step_all_fine)
-    fine_phi_ranges = (
-        best_angles[:, 0] - phi_step_all + phi_step_all_fine,
-        best_angles[:, 0] + phi_step_all - phi_step_all_fine + eps,
-    )  # plus eps to make endpoint inclusive
-    fine_phi_ranges_tensor = torch.rad2deg(torch.stack(fine_phi_ranges, dim=1))
-
-    # Now get angles using Hopf fibration
-    euler_angles = get_uniform_euler_angles(
-        in_plane_step=fine_in_plane_step,
-        out_of_plane_step=fine_out_of_plane_step,
-        phi_ranges=fine_phi_ranges_tensor,
-        theta_ranges=fine_theta_ranges_tensor,
-        psi_ranges=fine_psi_ranges_tensor,
-    )
-
-    return euler_angles
-'''

--- a/tests/test_torch_angular_search.py
+++ b/tests/test_torch_angular_search.py
@@ -1,26 +1,17 @@
 """Tests for `torch_angular_search` package."""
 
 from torch_angular_search.hopf_angles import get_uniform_euler_angles
-from torch_angular_search.refine_search import increase_resolution
+from torch_angular_search.refine_search import increased_resolution_grid
+
+# TODO: Check actual values of returned tensors
 
 
 def test_angle_generator():
     # Test the angle generator
     angles = get_uniform_euler_angles()
-    assert angles[0].shape[0] == 1562400
+    assert angles.shape == (1584960, 3)
 
 
 def test_increase_resolution():
-    angles_increased = increase_resolution()
-    print(f"shape pole increase res: {angles_increased[0].shape}")
-    assert angles_increased[0].shape[0] == 1344
-
-
-"""
-#deprecated
-def test_refine_angles():
-    best_angles = torch.tensor([[87, 87, 87], [45, 45, 45]])
-    angles_refined = refine_euler_angles(best_angles)
-    assert angles_refined[0].shape[0] == 37632
-    assert angles_refined[1].shape[0] == 39168
-"""
+    angles_increased = increased_resolution_grid()
+    assert angles_increased.shape == (1372, 3)


### PR DESCRIPTION
Fixes a minor bug where the actual angular sampling would be less than user requested `in_plane_step` or `out_of_plane_step` because of the behavior differences between `torch.linspace` and `torch.arange`. This pull request corrects the method so that theta and phi increments are actually what the user requests.

Also, the interface for `get_uniform_euler_angles` has changed to accept in angular ranges as float values and return a single `torch.Tensor`. Before, multiple potentially different range values could be supplied and the function would return a list of `torch.Tensor` objects across each of those ranges.

The refined grid function was also renamed to `increased_resolution_grid`.